### PR TITLE
Modfie cus main layout

### DIFF
--- a/brightcleanproject/lib/features/customer/presentation/checkout_screen.dart
+++ b/brightcleanproject/lib/features/customer/presentation/checkout_screen.dart
@@ -1,11 +1,79 @@
 import 'package:flutter/material.dart';
 import '../../../../core/theme/app_colors.dart';
+import 'package:intl/intl.dart';
 
-class CheckoutScreen extends StatelessWidget {
+class CheckoutScreen extends StatefulWidget {
   const CheckoutScreen({super.key});
 
   @override
+  State<CheckoutScreen> createState() => _CheckoutScreenState();
+}
+
+class _CheckoutScreenState extends State<CheckoutScreen> {
+  DateTime? _selectedDate;
+  String? _selectedTimeSlot;
+  String _selectedPaymentMethod = 'cash';
+  bool _isLocationVerified = false;
+
+  void _pickDate() async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? DateTime.now(),
+      firstDate: DateTime.now(), // Prevent selecting past dates
+      lastDate: DateTime.now().add(const Duration(days: 30)),
+    );
+    if (picked != null && picked != _selectedDate) {
+      setState(() {
+        _selectedDate = picked;
+      });
+    }
+  }
+
+  Widget _buildPaymentOption(String title, String value, IconData icon) {
+    final isSelected = _selectedPaymentMethod == value;
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _selectedPaymentMethod = value;
+        });
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: isSelected ? AppColors.primary.withOpacity(0.08) : Colors.white,
+          border: Border.all(
+            color: isSelected ? AppColors.primary : Colors.grey.shade300,
+            width: isSelected ? 2 : 1,
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: isSelected ? AppColors.primary : Colors.grey),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                title,
+                style: TextStyle(
+                  fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  color: isSelected ? AppColors.primary : AppColors.textMain,
+                ),
+              ),
+            ),
+            if (isSelected)
+              const Icon(Icons.check_circle, color: AppColors.primary),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final canCompleteOrder = _isLocationVerified && _selectedDate != null && _selectedTimeSlot != null;
+
     return Scaffold(
       appBar: AppBar(title: const Text('إتمام الطلب')),
       body: SingleChildScrollView(
@@ -17,78 +85,171 @@ class CheckoutScreen extends StatelessWidget {
             const Text('ملخص الطلب', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
             Card(
-              child: ListTile(
-                title: const Text('غسيل ملابس (غسيل وكي)'),
-                subtitle: const Text('الكمية: 5 قطع'),
-                trailing: const Text('50 درهم', style: TextStyle(fontWeight: FontWeight.bold)),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              elevation: 2,
+              child: const ListTile(
+                title: Text('غسيل ملابس (غسيل وكي)', style: TextStyle(fontWeight: FontWeight.bold)),
+                subtitle: Text('الكمية: 5 قطع'),
+                trailing: Text('50 درهم', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
               ),
             ),
             const SizedBox(height: 24),
             // Location
-            const Text('موقع التوصيل', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('موقع التوصيل', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                if (_isLocationVerified)
+                  const Row(
+                    children: [
+                      Icon(Icons.check_circle, color: AppColors.success, size: 16),
+                      SizedBox(width: 4),
+                      Text('تم التحقق', style: TextStyle(color: AppColors.success, fontSize: 12, fontWeight: FontWeight.bold)),
+                    ],
+                  )
+              ],
+            ),
             const SizedBox(height: 8),
             Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+                side: BorderSide(
+                  color: _isLocationVerified ? AppColors.success : Colors.transparent,
+                  width: 1,
+                )
+              ),
+              elevation: 2,
               child: ListTile(
-                leading: const Icon(Icons.location_on, color: AppColors.primary),
+                leading: Icon(Icons.location_on, color: _isLocationVerified ? AppColors.success : AppColors.primary),
                 title: const Text('المنزل'),
                 subtitle: const Text('شارع الشيخ زايد، دبي'),
-                trailing: TextButton(onPressed: () {}, child: const Text('تغيير')),
+                trailing: TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _isLocationVerified = true;
+                    });
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('تم التحقق من الموقع بنجاح')),
+                    );
+                  },
+                  child: Text(_isLocationVerified ? 'تغيير' : 'تأكيد الموقع'),
+                ),
               ),
             ),
             const SizedBox(height: 24),
-            // Delivery Time Slots
-            const Text('وقت التوصيل', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            // Delivery Date & Time
+            const Text('موعد الاستلام', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            DropdownButtonFormField<String>(
-              decoration: const InputDecoration(hintText: 'اختر الموعد'),
-              items: const [
-                DropdownMenuItem(value: 'morning', child: Text('09:00 ص - 12:00 م')),
-                DropdownMenuItem(value: 'afternoon', child: Text('12:00 م - 03:00 م')),
-                DropdownMenuItem(value: 'evening', child: Text('03:00 م - 06:00 م')),
+            Row(
+              children: [
+                Expanded(
+                  child: InkWell(
+                    onTap: _pickDate,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+                      decoration: BoxDecoration(
+                        border: Border.all(color: _selectedDate == null ? Colors.grey.shade400 : AppColors.primary),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(Icons.calendar_today, color: _selectedDate == null ? Colors.grey : AppColors.primary, size: 20),
+                          const SizedBox(width: 8),
+                          Text(
+                            _selectedDate == null
+                                ? 'اختر التاريخ'
+                                : DateFormat('yyyy/MM/dd').format(_selectedDate!),
+                            style: TextStyle(
+                              color: _selectedDate == null ? Colors.grey.shade700 : AppColors.primary,
+                              fontWeight: _selectedDate == null ? FontWeight.normal : FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    decoration: InputDecoration(
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+                      hintText: 'اختر الوقت',
+                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                    ),
+                    value: _selectedTimeSlot,
+                    items: const [
+                      DropdownMenuItem(value: 'morning', child: Text('09:00 - 12:00')),
+                      DropdownMenuItem(value: 'afternoon', child: Text('12:00 - 15:00')),
+                      DropdownMenuItem(value: 'evening', child: Text('15:00 - 18:00')),
+                    ],
+                    onChanged: (v) {
+                      setState(() {
+                        _selectedTimeSlot = v;
+                      });
+                    },
+                  ),
+                ),
               ],
-              onChanged: (v) {},
             ),
             const SizedBox(height: 24),
             // Payment Method
             const Text('طريقة الدفع', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            RadioGroup<String>(
-              groupValue: 'cash', // Fake logic for UI
-              onChanged: (String? v) {},
-              child: Column(
-                children: [
-                  RadioListTile<String>(
-                    title: const Text('دفع عند الاستلام'),
-                    value: 'cash',
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('بطاقة ائتمان'),
-                    value: 'card',
-                  ),
-                  RadioListTile<String>(
-                    title: const Text('المحفظة (150 درهم متوفر)'),
-                    value: 'wallet',
-                  ),
-                ],
-              ),
-            ),
+            _buildPaymentOption('دفع عند الاستلام', 'cash', Icons.money),
+            _buildPaymentOption('بطاقة ائتمان', 'card', Icons.credit_card),
+            _buildPaymentOption('المحفظة (150 درهم متوفر)', 'wallet', Icons.account_balance_wallet),
+            const SizedBox(height: 16),
             const Divider(),
+            const SizedBox(height: 8),
             const Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text('المجموع الكلي:', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                Text('50 درهم', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: AppColors.primary)),
+                Text('50 درهم', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: AppColors.primary)),
               ],
             ),
+            const SizedBox(height: 100), // padding for bottom bar
           ],
         ),
       ),
-      bottomNavigationBar: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: ElevatedButton(
-            onPressed: () {},
-            child: const Text('تأكيد الطلب'),
+      bottomSheet: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, -5),
+            ),
+          ],
+        ),
+        child: SafeArea(
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: canCompleteOrder
+                  ? () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('تم تأكيد الطلب بنجاح!')),
+                      );
+                    }
+                  : () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('الرجاء التحقق من الموقع واختيار موعد الاستلام لتأكيد الطلب'),
+                          backgroundColor: AppColors.error,
+                        ),
+                      );
+                    },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: canCompleteOrder ? AppColors.primary : Colors.grey.shade400,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              ),
+              child: const Text('تأكيد الطلب', style: TextStyle(fontSize: 18, color: Colors.white, fontWeight: FontWeight.bold)),
+            ),
           ),
         ),
       ),

--- a/brightcleanproject/lib/features/customer/presentation/customer_home_screen.dart
+++ b/brightcleanproject/lib/features/customer/presentation/customer_home_screen.dart
@@ -1,19 +1,89 @@
 import 'package:flutter/material.dart';
 import '../../../../core/theme/app_colors.dart';
 
-class CustomerHomeScreen extends StatelessWidget {
+class CustomerHomeScreen extends StatefulWidget {
   const CustomerHomeScreen({super.key});
 
+  @override
+  State<CustomerHomeScreen> createState() => _CustomerHomeScreenState();
+}
+
+class _CustomerHomeScreenState extends State<CustomerHomeScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  bool _isSearching = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(() {
+      setState(() {
+        _isSearching = _searchController.text.isNotEmpty;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
   Widget _buildCategoryCard(BuildContext context, String title, IconData icon, Color color) {
-    return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    return Container(
+      width: 120, // fixed width for horizontal scrolling
+      margin: const EdgeInsets.only(left: 16),
+      child: Card(
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 40, color: color),
+              const SizedBox(height: 8),
+              Text(
+                title,
+                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOfferCard(String title, String subtitle, Color bgColor) {
+    return Container(
+      width: 280,
+      margin: const EdgeInsets.only(left: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: bgColor.withOpacity(0.4),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          )
+        ]
+      ),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(icon, size: 40, color: color),
+          Text(title, style: const TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
-          Text(title, style: const TextStyle(fontWeight: FontWeight.bold), textAlign: TextAlign.center),
+          Text(
+            subtitle, 
+            style: const TextStyle(color: Colors.white70, fontSize: 14),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
         ],
       ),
     );
@@ -22,81 +92,144 @@ class CustomerHomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
-        title: const Text('برايت كلين'),
+        title: const Text('برايت كلين', style: TextStyle(fontWeight: FontWeight.bold)),
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        foregroundColor: AppColors.primary,
         actions: [
-          IconButton(icon: const Icon(Icons.local_offer), onPressed: () {}),
-          IconButton(icon: const Icon(Icons.search), onPressed: () {}),
-          IconButton(icon: const Icon(Icons.shopping_cart), onPressed: () {}),
+          IconButton(icon: const Icon(Icons.notifications_none), onPressed: () {}),
+          IconButton(icon: const Icon(Icons.shopping_cart_outlined), onPressed: () {}),
         ],
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // Ad Carousel Placeholder
-            Container(
-              height: 150,
-              decoration: BoxDecoration(
-                color: AppColors.lightBlue,
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: const Center(
-                child: Text('عروض الترويجية (Carousel)', style: TextStyle(color: AppColors.primary, fontSize: 18)),
-              ),
-            ),
-            const SizedBox(height: 24),
-            const Text('الخدمات', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 16),
-            // Categories Grid
-            GridView.count(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              crossAxisCount: 2,
-              crossAxisSpacing: 16,
-              mainAxisSpacing: 16,
-              children: [
-                _buildCategoryCard(context, 'الملابس', Icons.checkroom, AppColors.primary),
-                _buildCategoryCard(context, 'السجاد والمفروشات', Icons.dataset, AppColors.secondary),
-                _buildCategoryCard(context, 'السيارات', Icons.directions_car, AppColors.tertiary),
-                _buildCategoryCard(context, 'تنظيف المكيفات', Icons.ac_unit, Colors.teal),
-                _buildCategoryCard(context, 'عاملات النظافة', Icons.cleaning_services, Colors.pink),
-                _buildCategoryCard(context, 'تنظيف الخزانات', Icons.water_drop, Colors.blueAccent),
-              ],
-            ),
-            const SizedBox(height: 24),
-            const Text('آراء العملاء', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 16),
-            // Reviews Placeholder
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: Colors.grey.shade200),
-              ),
-              child: const Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(Icons.person, color: AppColors.textLight),
-                      SizedBox(width: 8),
-                      Text('أحمد محمد', style: TextStyle(fontWeight: FontWeight.bold)),
-                      Spacer(),
-                      Icon(Icons.star, color: Colors.amber, size: 16),
-                      Icon(Icons.star, color: Colors.amber, size: 16),
-                      Icon(Icons.star, color: Colors.amber, size: 16),
-                      Icon(Icons.star, color: Colors.amber, size: 16),
-                      Icon(Icons.star, color: Colors.amber, size: 16),
-                    ],
+            // Search Bar
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: _isSearching ? AppColors.primary.withOpacity(0.2) : Colors.black.withOpacity(0.05),
+                      blurRadius: _isSearching ? 8 : 4,
+                      spreadRadius: _isSearching ? 2 : 0,
+                    ),
+                  ],
+                ),
+                child: TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'ابحث عن خدمات...',
+                    prefixIcon: Icon(Icons.search, color: _isSearching ? AppColors.primary : Colors.grey),
+                    suffixIcon: _isSearching
+                        ? IconButton(
+                            icon: const Icon(Icons.clear, color: Colors.grey),
+                            onPressed: () {
+                              _searchController.clear();
+                              FocusScope.of(context).unfocus();
+                            },
+                          )
+                        : null,
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 14),
                   ),
-                  SizedBox(height: 8),
-                  Text('خدمة ممتازة وتوصيل سريع!'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            
+            // Offers Carousel (Horizontal Scroll)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Text('العروض الترويجية', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 150,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: [
+                  _buildOfferCard('خصم 20%', 'على غسيل السجاد والمفروشات', AppColors.primary),
+                  _buildOfferCard('غسيل مجاني', 'اغسل 5 قمصان والسادس مجاناً', AppColors.tertiary),
+                  _buildOfferCard('باقة التوفير', 'خصم خاص للاشتراكات الشهرية', Colors.teal),
                 ],
               ),
             ),
+            const SizedBox(height: 24),
+
+            // Categories (Horizontal Scroll)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Text('الخدمات', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 120, // Adjusted height for category cards
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: [
+                  _buildCategoryCard(context, 'الملابس', Icons.checkroom, AppColors.primary),
+                  _buildCategoryCard(context, 'السجاد والمفروشات', Icons.dataset, AppColors.secondary),
+                  _buildCategoryCard(context, 'السيارات', Icons.directions_car, AppColors.tertiary),
+                  _buildCategoryCard(context, 'تنظيف المكيفات', Icons.ac_unit, Colors.teal),
+                  _buildCategoryCard(context, 'عاملات النظافة', Icons.cleaning_services, Colors.pink),
+                  _buildCategoryCard(context, 'تنظيف الخزانات', Icons.water_drop, Colors.blueAccent),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Reviews
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Text('آراء العملاء', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: Colors.grey.shade200),
+                ),
+                child: const Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        CircleAvatar(
+                          radius: 16,
+                          backgroundColor: AppColors.lightBlue,
+                          child: Icon(Icons.person, color: AppColors.primary, size: 20),
+                        ),
+                        SizedBox(width: 8),
+                        Text('أحمد محمد', style: TextStyle(fontWeight: FontWeight.bold)),
+                        Spacer(),
+                        Icon(Icons.star, color: Colors.amber, size: 16),
+                        Icon(Icons.star, color: Colors.amber, size: 16),
+                        Icon(Icons.star, color: Colors.amber, size: 16),
+                        Icon(Icons.star, color: Colors.amber, size: 16),
+                        Icon(Icons.star, color: Colors.amber, size: 16),
+                      ],
+                    ),
+                    SizedBox(height: 12),
+                    Text('خدمة ممتازة وتوصيل سريع! ملابسي عادت كأنها جديدة.', style: TextStyle(color: Colors.black87)),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 32),
           ],
         ),
       ),

--- a/brightcleanproject/lib/features/customer/presentation/customer_main_layout.dart
+++ b/brightcleanproject/lib/features/customer/presentation/customer_main_layout.dart
@@ -14,33 +14,75 @@ class CustomerMainLayout extends StatefulWidget {
 class _CustomerMainLayoutState extends State<CustomerMainLayout> {
   int _currentIndex = 0;
 
-  final List<Widget> _pages = [
-    const CustomerHomeScreen(),
-    const MyOrdersScreen(),
-    const ProfileScreen(),
+  final List<Widget> _pages = const [
+    CustomerHomeScreen(),
+    MyOrdersScreen(),
+    ProfileScreen(),
   ];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: IndexedStack(
-        index: _currentIndex,
-        children: _pages,
+      body: Stack(
+        children: List.generate(_pages.length, (index) {
+          final isSelected = _currentIndex == index;
+          return IgnorePointer(
+            ignoring: !isSelected,
+            child: AnimatedOpacity(
+              opacity: isSelected ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+              child: _pages[index],
+            ),
+          );
+        }),
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        selectedItemColor: AppColors.primary,
-        unselectedItemColor: Colors.grey,
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'الرئيسية'),
-          BottomNavigationBarItem(icon: Icon(Icons.receipt_long), label: 'طلباتي'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'حسابي'),
-        ],
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, -5),
+            ),
+          ],
+        ),
+        child: BottomNavigationBar(
+          currentIndex: _currentIndex,
+          onTap: (index) {
+            if (_currentIndex != index) {
+              setState(() {
+                _currentIndex = index;
+              });
+            }
+          },
+          elevation: 0,
+          backgroundColor: Colors.white,
+          selectedItemColor: AppColors.primary,
+          unselectedItemColor: Colors.grey.shade500,
+          showSelectedLabels: true,
+          showUnselectedLabels: true,
+          type: BottomNavigationBarType.fixed,
+          selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+          unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.normal, fontSize: 12),
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home_outlined),
+              activeIcon: Icon(Icons.home),
+              label: 'الرئيسية',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.receipt_long_outlined),
+              activeIcon: Icon(Icons.receipt_long),
+              label: 'طلباتي',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person_outline),
+              activeIcon: Icon(Icons.person),
+              label: 'حسابي',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/brightcleanproject/lib/features/customer/presentation/my_orders_screen.dart
+++ b/brightcleanproject/lib/features/customer/presentation/my_orders_screen.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_colors.dart';
 
 class MyOrdersScreen extends StatelessWidget {
   const MyOrdersScreen({super.key});
 
-  Widget _buildStep(String title, bool isActive) {
+  Widget _buildStep(String title, bool isActive, {Color activeColor = AppColors.success}) {
     return Column(
       children: [
         CircleAvatar(
           radius: 12,
-          backgroundColor: isActive ? AppColors.success : Colors.grey.shade300,
+          backgroundColor: isActive ? activeColor : Colors.grey.shade300,
           child: isActive ? const Icon(Icons.check, size: 16, color: Colors.white) : null,
         ),
         const SizedBox(height: 4),
@@ -18,38 +19,126 @@ class MyOrdersScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildOrderCard() {
+  Widget _buildOrderCard({
+    required String orderId,
+    required String date,
+    required String details,
+    required String status,
+    required Color statusColor,
+    bool showTracker = true,
+    int activeStepIndex = 1,
+  }) {
     return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       margin: const EdgeInsets.only(bottom: 16),
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('طلب رقم #1024', style: TextStyle(fontWeight: FontWeight.bold)),
-                Text('15 أبريل 2026', style: TextStyle(color: Colors.grey)),
-              ],
-            ),
-            const SizedBox(height: 8),
-            const Text('غسيل ملابس - 5 قطع'),
-            const SizedBox(height: 16),
-            // Progress Tracker
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                _buildStep('قيد الانتظار', true),
-                const Expanded(child: Divider(color: AppColors.success, thickness: 2)),
-                _buildStep('في الطريق', true),
-                const Expanded(child: Divider(color: Colors.grey, thickness: 2)),
-                _buildStep('قيد المعالجة', false),
-                const Expanded(child: Divider(color: Colors.grey, thickness: 2)),
-                _buildStep('جاهز', false),
-                const Expanded(child: Divider(color: Colors.grey, thickness: 2)),
-                _buildStep('تم التوصيل', false),
+                Text('طلب رقم #$orderId', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: statusColor.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: statusColor.withOpacity(0.5)),
+                  ),
+                  child: Text(
+                    status,
+                    style: TextStyle(color: statusColor, fontWeight: FontWeight.bold, fontSize: 12),
+                  ),
+                ),
               ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(details, style: const TextStyle(color: AppColors.textMain, fontSize: 14)),
+                Text(date, style: const TextStyle(color: Colors.grey, fontSize: 12)),
+              ],
+            ),
+            if (showTracker) ...[
+              const SizedBox(height: 16),
+              const Divider(),
+              const SizedBox(height: 8),
+              // Progress Tracker
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _buildStep('قيد الانتظار', activeStepIndex >= 0, activeColor: AppColors.success),
+                  Expanded(child: Divider(color: activeStepIndex >= 1 ? AppColors.success : Colors.grey, thickness: 2)),
+                  _buildStep('في الطريق', activeStepIndex >= 1, activeColor: AppColors.success),
+                  Expanded(child: Divider(color: activeStepIndex >= 2 ? AppColors.success : Colors.grey, thickness: 2)),
+                  _buildStep('قيد المعالجة', activeStepIndex >= 2, activeColor: AppColors.success),
+                  Expanded(child: Divider(color: activeStepIndex >= 3 ? AppColors.success : Colors.grey, thickness: 2)),
+                  _buildStep('جاهز', activeStepIndex >= 3, activeColor: AppColors.success),
+                  Expanded(child: Divider(color: activeStepIndex >= 4 ? AppColors.success : Colors.grey, thickness: 2)),
+                  _buildStep('تم التوصيل', activeStepIndex >= 4, activeColor: AppColors.success),
+                ],
+              ),
+            ]
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, {required String title, required String subtitle, required IconData icon}) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                color: AppColors.lightBlue.withOpacity(0.3),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                icon,
+                size: 64,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textMain,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.grey,
+              ),
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () {
+                context.pushReplacement('/customer_home');
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('اطلب الآن', style: TextStyle(color: AppColors.white)),
             ),
           ],
         ),
@@ -62,14 +151,23 @@ class MyOrdersScreen extends StatelessWidget {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
+        backgroundColor: AppColors.background,
         appBar: AppBar(
-          title: const Text('طلباتي'),
+          title: const Text('طلباتي', style: TextStyle(fontWeight: FontWeight.bold)),
+          centerTitle: true,
+          backgroundColor: AppColors.white,
+          foregroundColor: AppColors.primary,
+          elevation: 0,
           bottom: const TabBar(
+            labelColor: AppColors.primary,
+            unselectedLabelColor: Colors.grey,
+            indicatorColor: AppColors.primary,
+            indicatorWeight: 3,
+            labelStyle: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             tabs: [
               Tab(text: 'الطلبات الحالية'),
               Tab(text: 'الطلبات السابقة'),
             ],
-            indicatorColor: AppColors.lightBlue,
           ),
         ),
         body: TabBarView(
@@ -78,11 +176,33 @@ class MyOrdersScreen extends StatelessWidget {
             ListView(
               padding: const EdgeInsets.all(16),
               children: [
-                _buildOrderCard(),
+                _buildOrderCard(
+                  orderId: '1024',
+                  date: '15 أبريل 2026',
+                  details: 'غسيل ملابس - 5 قطع',
+                  status: 'في الطريق',
+                  statusColor: AppColors.warning,
+                  activeStepIndex: 1,
+                  showTracker: true,
+                ),
+                _buildOrderCard(
+                  orderId: '1025',
+                  date: '16 أبريل 2026',
+                  details: 'تنظيف سجاد - 2 قطعة',
+                  status: 'قيد الانتظار',
+                  statusColor: AppColors.warning,
+                  activeStepIndex: 0,
+                  showTracker: true,
+                ),
               ],
             ),
-            // Past Orders
-            const Center(child: Text('لا توجد طلبات سابقة')),
+            // Past Orders (Empty State Example)
+            _buildEmptyState(
+              context,
+              title: 'لا توجد طلبات سابقة',
+              subtitle: 'يبدو أنك لم تقم بأي طلبات في الماضي. اطلب الآن لتجربة خدماتنا المميزة.',
+              icon: Icons.receipt_long_rounded,
+            ),
           ],
         ),
       ),

--- a/brightcleanproject/lib/features/customer/presentation/service_details_screen.dart
+++ b/brightcleanproject/lib/features/customer/presentation/service_details_screen.dart
@@ -12,6 +12,9 @@ class ServiceDetailsScreen extends StatefulWidget {
 
 class _ServiceDetailsScreenState extends State<ServiceDetailsScreen> {
   int quantity = 1;
+  final double basePrice = 10.0;
+
+  double get totalPrice => basePrice * quantity;
 
   Widget _buildClothesForm() {
     return Column(
@@ -70,9 +73,9 @@ class _ServiceDetailsScreenState extends State<ServiceDetailsScreen> {
                 Row(
                   children: [
                     IconButton(
-                      icon: const Icon(Icons.remove_circle, color: AppColors.primary),
+                      icon: Icon(Icons.remove_circle, color: quantity > 0 ? AppColors.primary : Colors.grey),
                       onPressed: () {
-                        if (quantity > 1) setState(() => quantity--);
+                        if (quantity > 0) setState(() => quantity--);
                       },
                     ),
                     Text('$quantity', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
@@ -86,6 +89,16 @@ class _ServiceDetailsScreenState extends State<ServiceDetailsScreen> {
                 ),
               ],
             ),
+            const SizedBox(height: 24),
+            const Divider(),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('السعر الإجمالي:', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                Text('${totalPrice.toStringAsFixed(2)} درهم', style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: AppColors.primary)),
+              ],
+            ),
           ],
         ),
       ),
@@ -93,8 +106,22 @@ class _ServiceDetailsScreenState extends State<ServiceDetailsScreen> {
         child: Padding(
           padding: const EdgeInsets.all(16.0),
           child: ElevatedButton(
-            onPressed: () {},
-            child: const Text('إضافة إلى السلة / متابعة للإكمال'),
+            onPressed: quantity > 0 ? () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('تم إضافة $quantity عنصر إلى السلة بنجاح!'),
+                  backgroundColor: AppColors.success,
+                  behavior: SnackBarBehavior.floating,
+                ),
+              );
+            } : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('إضافة إلى السلة / متابعة للإكمال', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
           ),
         ),
       ),


### PR DESCRIPTION
تم تعديل شريط التنقل السفلي (Bottom Navigation Bar) وتحديث تفاعلاته بنجاح! إليك تفاصيل ما قمت به:

انتقالات سلسة (Smooth Transitions):

قمت باستبدال التنقل الفوري (الذي كان يتم عبر IndexedStack) بنظام طبقات (Stack) مع شفافية متحركة (AnimatedOpacity).
الآن، عند التنقل بين (الرئيسية، طلباتي، حسابي)، تتلاشى الشاشة السابقة وتظهر الشاشة الجديدة بانتقال تدريجي ناعم (Fade-in / Fade-out) يستغرق 300 جزء من الثانية.
الحفاظ على حالة الشاشة (Maintain State):

من خلال استخدام بنية الطبقات (Stack) وتفعيل/تعطيل التفاعل عبر IgnorePointer، تبقى جميع الشاشات محملة في الخلفية. هذا يعني أنك إذا قمت بالتمرير لأسفل في "الرئيسية" ثم ذهبت لـ "طلباتي" وعدت، ستجد الشاشة "الرئيسية" كما تركتها تماماً دون إعادة تحميل من الصفر.
تحديث الأيقونات (Active/Inactive Icons):

قمت ببرمجة الأيقونات لتعكس حالة التبويب بشكل أكثر احترافية.
في حالة عدم التحديد (Inactive)، تظهر الأيقونة مفرغة (Outlined) (مثل home_outlined و person_outline).
بمجرد الضغط عليها (Active)، تتحول لتصبح أيقونة ممتلئة وبارزة باللون الأساسي للتطبيق.
تمت إضافة ظل خفيف (Shadow) وتنسيق لخطوط النصوص لزيادة جمالية الشريط.