### PR TITLE
Adding hard coded accounts

### DIFF
--- a/brightcleanproject/lib/core/database/database_helper.dart
+++ b/brightcleanproject/lib/core/database/database_helper.dart
@@ -34,12 +34,16 @@ CREATE TABLE users (
 )
 ''');
     
-    // Insert seed data
-    await db.insert('users', {
-      'phone': '0500000000',
-      'password': 'password1234',
-      'role': 'customer',
-    });
+    // Insert seed data for testing
+    final testUsers = [
+      {'phone': '0500000000', 'password': 'Password123', 'role': 'Admin'},
+      {'phone': '0511111111', 'password': 'Password123', 'role': 'Manager'},
+      {'phone': '0522222222', 'password': 'Password123', 'role': 'Customer'},
+    ];
+    
+    for (var user in testUsers) {
+      await db.insert('users', user);
+    }
   }
 
   Future<Map<String, dynamic>?> loginUser(String phone, String password) async {

--- a/brightcleanproject/lib/core/database/database_helper.dart
+++ b/brightcleanproject/lib/core/database/database_helper.dart
@@ -39,6 +39,7 @@ CREATE TABLE users (
       {'phone': '0500000000', 'password': 'Password123', 'role': 'Admin'},
       {'phone': '0511111111', 'password': 'Password123', 'role': 'Manager'},
       {'phone': '0522222222', 'password': 'Password123', 'role': 'Customer'},
+      {'phone': '0533333333', 'password': 'Password123', 'role': 'Driver'},
     ];
     
     for (var user in testUsers) {

--- a/brightcleanproject/lib/features/auth/presentation/login_screen.dart
+++ b/brightcleanproject/lib/features/auth/presentation/login_screen.dart
@@ -128,7 +128,7 @@ class _LoginScreenState extends State<LoginScreen> {
           _handleLogin();
         });
       },
-      backgroundColor: AppColors.primary.withOpacity(0.1),
+      backgroundColor: AppColors.primary.withValues(alpha: 0.1),
       side: const BorderSide(color: AppColors.primary),
     );
   }

--- a/brightcleanproject/lib/features/auth/presentation/login_screen.dart
+++ b/brightcleanproject/lib/features/auth/presentation/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/custom_text_field.dart';
@@ -78,6 +79,49 @@ class _LoginScreenState extends State<LoginScreen> {
         }
       }
     }
+  }
+
+  Widget _buildDebugLoginSection() {
+    return Column(
+      children: [
+        const Divider(),
+        const SizedBox(height: 16),
+        Text(
+          'حسابات تجريبية (للتطوير فقط)',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: AppColors.textLight,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          alignment: WrapAlignment.center,
+          children: [
+            _debugLoginButton('مدير النظام', '0500000000', 'Password123'),
+            _debugLoginButton('المدير', '0511111111', 'Password123'),
+            _debugLoginButton('عميل', '0522222222', 'Password123'),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _debugLoginButton(String role, String phone, String password) {
+    return ActionChip(
+      label: Text(role),
+      onPressed: () {
+        _phoneController.text = phone;
+        _passwordController.text = password;
+        // Small delay to ensure UI updates fields before logging in
+        Future.delayed(const Duration(milliseconds: 100), () {
+          _handleLogin();
+        });
+      },
+      backgroundColor: AppColors.primary.withOpacity(0.1),
+      side: const BorderSide(color: AppColors.primary),
+    );
   }
 
   @override
@@ -202,6 +246,10 @@ class _LoginScreenState extends State<LoginScreen> {
                         ),
                       ],
                     ),
+                    if (kDebugMode) ...[
+                      const SizedBox(height: 24),
+                      _buildDebugLoginSection(),
+                    ],
                   ],
                 ),
               ),

--- a/brightcleanproject/lib/features/auth/presentation/login_screen.dart
+++ b/brightcleanproject/lib/features/auth/presentation/login_screen.dart
@@ -102,6 +102,7 @@ class _LoginScreenState extends State<LoginScreen> {
             _debugLoginButton('مدير النظام', '0500000000', 'Password123'),
             _debugLoginButton('المدير', '0511111111', 'Password123'),
             _debugLoginButton('عميل', '0522222222', 'Password123'),
+            _debugLoginButton('مندوب التوصيل', '0533333333', 'Password123'),
           ],
         ),
       ],

--- a/brightcleanproject/lib/features/auth/presentation/login_screen.dart
+++ b/brightcleanproject/lib/features/auth/presentation/login_screen.dart
@@ -23,6 +23,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   // State variable to manage the loading indicator
   bool _isLoading = false;
+  bool _loginInProgress = false;
 
   @override
   void dispose() {
@@ -32,8 +33,11 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   void _handleLogin() async {
+    if (_loginInProgress) return;
+    _loginInProgress = true;
+
     // Validate the form fields based on provided validators
-    if (_formKey.currentState!.validate()) {
+    if (_formKey.currentState?.validate() ?? false) {
       setState(() {
         _isLoading = true;
       });
@@ -77,7 +81,10 @@ class _LoginScreenState extends State<LoginScreen> {
             _isLoading = false;
           });
         }
+        _loginInProgress = false;
       }
+    } else {
+      _loginInProgress = false;
     }
   }
 
@@ -117,6 +124,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _passwordController.text = password;
         // Small delay to ensure UI updates fields before logging in
         Future.delayed(const Duration(milliseconds: 100), () {
+          if (!mounted || _loginInProgress) return;
           _handleLogin();
         });
       },

--- a/brightcleanproject/pubspec.yaml
+++ b/brightcleanproject/pubspec.yaml
@@ -22,9 +22,10 @@ environment:
   sdk: ^3.2.3
   flutter: ">=3.16.0"
 
-# Why? Flutter 3.16.0 (which shipped with Dart 3.2.3) was a massive release because it made Material 3 the default design system.
-# Since your app seems to use modern UI elements, setting your minimum to 3.16.0 guarantees that anyone compiling your app 
-# will render the exact same modern Material 3 widgets you are seeing.
+# Why? Flutter 3.16.0 (which shipped with Dart 3.2.3) was a massive release because it made Material 3 
+# the default design system. Since your app seems to use modern UI elements, setting your minimum to 
+# 3.16.0 guarantees that anyone compiling your app will render the exact same modern Material 3 
+# widgets you are seeing.
 
 
 # Dependencies specify other packages that your package needs in order to work.

--- a/brightcleanproject/pubspec.yaml
+++ b/brightcleanproject/pubspec.yaml
@@ -19,7 +19,13 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.10.8
+  sdk: ^3.2.3
+  flutter: ">=3.16.0"
+
+# Why? Flutter 3.16.0 (which shipped with Dart 3.2.3) was a massive release because it made Material 3 the default design system.
+# Since your app seems to use modern UI elements, setting your minimum to 3.16.0 guarantees that anyone compiling your app 
+# will render the exact same modern Material 3 widgets you are seeing.
+
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Add hardcoded test account buttons to the login screen for quick access and faster testing; auto-fill credentials and log in on click, restricted to development mode only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded seed data to create multiple predefined user accounts with distinct roles and updated test credentials.
  * Added debug-only quick-access login chips for faster role-based sign-in during development.

* **Bug Fixes**
  * Improved login flow stability by preventing duplicate submissions and ensuring progress state is reliably reset after validation or async completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->